### PR TITLE
Fixed ARC leak bug and MIDI network session bug

### DIFF
--- a/Sources/PGMidi/PGArc.h
+++ b/Sources/PGMidi/PGArc.h
@@ -31,7 +31,9 @@ template <typename OBJC_TYPE, typename SOURCE_TYPE>
 inline
 OBJC_TYPE *arc_cast(SOURCE_TYPE *source)
 {
-    return (__bridge OBJC_TYPE*)source;
+    @autoreleasepool {
+        return (__bridge OBJC_TYPE*)source;
+    }
 }
 
 #endif

--- a/Sources/PGMidi/PGMidi.mm
+++ b/Sources/PGMidi/PGMidi.mm
@@ -233,7 +233,7 @@ void PGMIDIReadProc(const MIDIPacketList *pktlist, void *readProcRefCon, void *s
 - (void) enableNetwork:(BOOL)enabled
 {
     MIDINetworkSession* session = [MIDINetworkSession defaultSession];
-    session.enabled = YES;
+    session.enabled = enabled;
     session.connectionPolicy = MIDINetworkConnectionPolicy_Anyone;
 }
 


### PR DESCRIPTION
Hi Pete,

Two changes: wrapped an @autorelease scope around the packet transfer code in PGArc.h and fixed a stuck boolean in the network session code. Thanks for this.

Cheers,

Tim