### PR TITLE
Enable Background Mode, Set Virtual ports to Enabled.

### DIFF
--- a/Resources/MidiMonitor-Info.plist
+++ b/Resources/MidiMonitor-Info.plist
@@ -38,5 +38,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/Sources/PGMidi/PGMidi.mm
+++ b/Sources/PGMidi/PGMidi.mm
@@ -399,7 +399,7 @@ void PGMIDIVirtualDestinationReadProc(const MIDIPacketList *pktlist, void *readP
 
         [delegate midi:self sourceAdded:virtualDestinationSource];
         [[NSNotificationCenter defaultCenter] postNotificationName:PGMidiSourceAddedNotification
-                                                            object:self 
+                                                            object:self
                                                           userInfo:[NSDictionary dictionaryWithObject:virtualDestinationSource
                                                                                                forKey:PGMidiConnectionKey]];
     }

--- a/Sources/PGMidi/PGMidi.mm
+++ b/Sources/PGMidi/PGMidi.mm
@@ -330,11 +330,7 @@ void PGMIDIVirtualDestinationReadProc(const MIDIPacketList *pktlist, void *readP
     
     if (virtualSourceEnabled)
     {
-        NSString *name
-            = virtualEndpointName
-            ? virtualEndpointName
-            : [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString*)kCFBundleNameKey];
-        OSStatus s = MIDISourceCreate(client, (__bridge CFStringRef)name, &virtualSourceEndpoint);
+        OSStatus s = MIDISourceCreate(client, (__bridge CFStringRef)@"MidiMonitor Source", &virtualSourceEndpoint);
         NSLogError(s, @"Create MIDI virtual source");
         if (s) return;
         
@@ -374,11 +370,7 @@ void PGMIDIVirtualDestinationReadProc(const MIDIPacketList *pktlist, void *readP
     
     if (virtualDestinationEnabled)
     {
-        NSString *name
-            = virtualEndpointName
-            ? virtualEndpointName
-            : [[[NSBundle mainBundle] infoDictionary] valueForKey:(NSString*)kCFBundleNameKey];
-        OSStatus s = MIDIDestinationCreate(client, (__bridge CFStringRef)name, PGMIDIVirtualDestinationReadProc, (__bridge void*)self, &virtualDestinationEndpoint);
+        OSStatus s = MIDIDestinationCreate(client, (__bridge CFStringRef)@"MidiMonitor Destination", PGMIDIVirtualDestinationReadProc, (__bridge void*)self, &virtualDestinationEndpoint);
         NSLogError(s, @"Create MIDI virtual destination");
         if (s) return;
         

--- a/Sources/UI/MidiMonitorAppDelegate.m
+++ b/Sources/UI/MidiMonitorAppDelegate.m
@@ -28,7 +28,9 @@
         // We only create a MidiInput object on iOS versions that support CoreMIDI
         midi = [[PGMidi alloc] init];
         midi.networkEnabled = YES;
-        viewController.midi = midi;
+		viewController.midi = midi;
+		midi.virtualDestinationEnabled = YES;
+		midi.virtualSourceEnabled = YES;
     )
 
 	return YES;

--- a/Sources/UI/MidiMonitorViewController.mm
+++ b/Sources/UI/MidiMonitorViewController.mm
@@ -61,21 +61,18 @@ NSString *ToString(PGMidiConnection *connection)
 }
 - (IBAction) listAllInterfaces
 {
-    IF_IOS_HAS_COREMIDI
-    ({
-        [self addString:@"\n\nInterface list:"];
-        for (PGMidiSource *source in midi.sources)
-        {
-            NSString *description = [NSString stringWithFormat:@"Source: %@", ToString(source)];
-            [self addString:description];
-        }
-        [self addString:@""];
-        for (PGMidiDestination *destination in midi.destinations)
-        {
-            NSString *description = [NSString stringWithFormat:@"Destination: %@", ToString(destination)];
-            [self addString:description];
-        }
-    })
+	[self addString:@"\n\nInterface list:"];
+	for (PGMidiSource *source in midi.sources)
+	{
+		NSString *description = [NSString stringWithFormat:@"Source: %@", ToString(source)];
+		[self addString:description];
+	}
+	[self addString:@""];
+	for (PGMidiDestination *destination in midi.destinations)
+	{
+		NSString *description = [NSString stringWithFormat:@"Destination: %@", ToString(destination)];
+		[self addString:description];
+	}
 }
 
 - (IBAction) sendMidiData


### PR DESCRIPTION
I have enabled VirtualMidiPorts in this fork. MIDIDestinationCreate fails with a -10844, (kMIDINotPermitted) OSStatus unless you have the audio key set for UIBackgroundModes.

Using TouchOSC, I see both the source and the destination. I know that MIDI Events are being sent, however the callback procs in MidiMonitor are never called.

These changes at least enable the VirtualMidi functionality. Would love to solve this mystery.