### PR TITLE
Added OSX/iOS Target Conditionals

### DIFF
--- a/Sources/PGMidi/PGMidi.h
+++ b/Sources/PGMidi/PGMidi.h
@@ -3,6 +3,8 @@
 //  PGMidi
 //
 
+#import "TargetConditionals.h"
+
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     #import <UIKit/UIKit.h>
 #else


### PR DESCRIPTION
Added the SDK (part of Mac and iOS SDKs) header "TargetConditionals.h" to make it easier to use the PGMIDI Sources
as a Drop-in with no additional configuration. Before the build process would fail because the device
target macros couldnt be found.
