### PR TITLE
ios9 and above fix

### DIFF
--- a/Sources/UI/MidiMonitorAppDelegate.m
+++ b/Sources/UI/MidiMonitorAppDelegate.m
@@ -20,6 +20,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    self.window.rootViewController = viewController;
     [window addSubview:viewController.view];
     [window makeKeyAndVisible];
 


### PR DESCRIPTION
app window’s rootviewcontroller needs to be set for the app to run correctly on ios9 and above. 